### PR TITLE
feat: Add custom time units and calendar support for NetCDF output

### DIFF
--- a/doc/pycmor_building_blocks.rst
+++ b/doc/pycmor_building_blocks.rst
@@ -100,6 +100,40 @@ Here's an example of a rule:
 Inheritance
 -----------
 
+Time Units and Calendar Configuration
+------------------------------------
+
+When working with time-dependent data, you can specify custom time units and calendar types in your rule configuration. This is particularly useful for historical experiments or when working with models that use non-standard calendars.
+
+Example configuration:
+
+.. code-block:: yaml
+
+    rules:
+      - name: historical_experiment
+        cmor_variable: "tas"
+        # ... other required fields ...
+        
+        # Custom time configuration
+        time_units: "days since 1850-01-01"  # CF-compliant time units
+        time_calendar: "proleptic_gregorian"  # Calendar type
+
+Time Units:
+- Must follow the CF convention: "<units> since <reference date>"
+- Supported units: days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds
+- Example: "days since 1850-01-01", "hours since 2000-01-01 00:00:00"
+
+Calendar Types:
+- ``standard`` or ``gregorian``: Standard Gregorian calendar (default)
+- ``proleptic_gregorian``: Gregorian calendar extended to dates before 1582-10-15
+- ``noleap`` or ``365_day``: No leap years, all years are 365 days
+- ``all_leap`` or ``366_day``: All years are leap years (366 days)
+- ``360_day``: All years are 360 days divided into 30-day months
+- ``julian``: Julian calendar
+- ``none``: No calendar
+
+If not specified, the default calendar is "standard" and the time units will be determined from the input data.
+
 Rules can inherit global values. To do so, you should include them in the ``inherit`` section of the configuration file. Here is an example:
 
   .. code-block:: yaml

--- a/src/pycmor/core/validate.py
+++ b/src/pycmor/core/validate.py
@@ -208,6 +208,26 @@ RULES_SCHEMA = {
                 "model_component": {"type": "string", "required": True},
                 "grid_label": {"type": "string", "required": True},
                 "array_order": {"type": "list", "required": False},
+                "time_units": {
+                    "type": "string",
+                    "required": False,
+                    "regex": r"^\s*(days|hours|minutes|seconds|milliseconds|microseconds|nanoseconds)\s+since\s+\d{4}-\d{2}-\d{2}(\s+\d{2}:\d{2}:\d{2}(.\d+)?)?\s*$",
+                    "description": "Time units in CF convention format (e.g., 'days since 1850-01-01')"
+                },
+                "time_calendar": {
+                    "type": "string",
+                    "required": False,
+                    "allowed": [
+                        "standard", "gregorian",  # Gregorian/standard calendar (default)
+                        "proleptic_gregorian",   # Gregorian calendar extended to dates before 1582-10-15
+                        "noleap", "365_day",     # No leap years, all years are 365 days
+                        "all_leap", "366_day",   # All years are leap years (366 days)
+                        "360_day",               # All years are 360 days divided into 30 day months
+                        "julian",                # Julian calendar
+                        "none"                   # No calendar
+                    ],
+                    "description": "Calendar type for time calculations"
+                },
             },
         },
     },

--- a/src/pycmor/std_lib/files.py
+++ b/src/pycmor/std_lib/files.py
@@ -239,12 +239,58 @@ def _save_dataset_with_native_timespan(
 ):
     paths = []
     datasets = split_data_timespan(da, rule)
-    for group_ds in datasets:
-        paths.append(create_filepath(group_ds, rule))
+
+    # Ensure time encoding is properly applied to each dataset
+    for i, ds in enumerate(datasets):
+        if time_label in ds.variables:
+            # If we have custom units and calendar, use xarray's CF encoding function
+            # Only apply if both are actual strings (not Mock objects or None)
+            if (
+                "units" in time_encoding
+                and "calendar" in time_encoding
+                and isinstance(time_encoding["units"], str)
+                and isinstance(time_encoding["calendar"], str)
+            ):
+                from xarray.coding.times import encode_cf_datetime
+
+                # Get the current time values (should be datetime objects)
+                time_values = ds[time_label].values
+
+                # Use xarray's CF encoding function to encode the datetime values
+                encoded_values, _, _ = encode_cf_datetime(
+                    time_values,
+                    units=time_encoding["units"],
+                    calendar=time_encoding["calendar"],
+                )
+
+                # Replace the time coordinate with the encoded values
+                ds[time_label] = xr.DataArray(
+                    encoded_values, dims=[time_label], attrs=ds[time_label].attrs.copy()
+                )
+
+            # Set time units and calendar as attributes for consistency
+            # Only set if they are actual strings (not Mock objects)
+            # But avoid setting calendar attribute if it conflicts with encoding
+            if "units" in time_encoding and isinstance(time_encoding["units"], str):
+                ds[time_label].attrs["units"] = time_encoding["units"]
+            # Only set calendar attribute if we have custom calendar (not default "standard")
+            if (
+                "calendar" in time_encoding
+                and isinstance(time_encoding["calendar"], str)
+                and time_encoding["calendar"] != "standard"
+            ):
+                ds[time_label].attrs["calendar"] = time_encoding["calendar"]
+
+            # Also set the encoding directly on the variable
+            ds[time_label].encoding.update(time_encoding)
+
+        paths.append(create_filepath(ds, rule))
+
+    # Don't pass encoding to save_mfdataset since we've already encoded the time values
+    # and set the attributes - let xarray use what we've provided
     return xr.save_mfdataset(
         datasets,
         paths,
-        encoding={time_label: time_encoding},
         **extra_kwargs,
     )
 
@@ -292,6 +338,20 @@ def save_dataset(da: xr.DataArray, rule):
         extra_kwargs.update({"unlimited_dims": ["time"]})
     time_encoding = {"dtype": time_dtype}
     time_encoding = {k: v for k, v in time_encoding.items() if v is not None}
+    # Allow user to define time units and calendar in the rule object
+    # Martina has a usecase where she wants to set time units to
+    # `days since 1850-01-01` and calendar to `proleptic_gregorian` for
+    # historical experiments. See issue #215
+    time_units = getattr(rule, "time_units", None)
+    time_calendar = getattr(rule, "time_calendar", None)
+    # Only add to encoding if they are actual strings (not Mock objects or None)
+    if time_units is not None and isinstance(time_units, str):
+        time_encoding["units"] = time_units
+    if time_calendar is not None and isinstance(time_calendar, str):
+        time_encoding["calendar"] = time_calendar
+    # Set default calendar if none is specified
+    if time_encoding.get("calendar") is None:
+        time_encoding["calendar"] = "standard"
     if not has_time_axis(da):
         filepath = create_filepath(da, rule)
         return da.to_netcdf(
@@ -311,8 +371,8 @@ def save_dataset(da: xr.DataArray, rule):
         )
     if isinstance(da, xr.DataArray):
         da = da.to_dataset()
-    # Not sure about this, maybe it needs to go above, before the is_scalar
-    # check
+
+    # Set time variable attributes
     if rule._pycmor_cfg("xarray_time_set_standard_name"):
         da[time_label].attrs["standard_name"] = "time"
     if rule._pycmor_cfg("xarray_time_set_long_name"):
@@ -322,6 +382,53 @@ def save_dataset(da: xr.DataArray, rule):
         da[time_label].attrs["axis"] = time_axis_str
     if rule._pycmor_cfg("xarray_time_remove_fill_value_attr"):
         time_encoding["_FillValue"] = None
+
+    # If we have custom units and calendar, use xarray's CF encoding function
+    # Only apply if both are actual strings (not Mock objects or None)
+    if (
+        "units" in time_encoding
+        and "calendar" in time_encoding
+        and isinstance(time_encoding["units"], str)
+        and isinstance(time_encoding["calendar"], str)
+    ):
+        from xarray.coding.times import encode_cf_datetime
+
+        # Convert the dataset to Dataset if it's a DataArray
+        if isinstance(da, xr.DataArray):
+            da = da.to_dataset()
+
+        # Get the current time values (should be datetime objects)
+        time_values = da[time_label].values
+
+        # Use xarray's CF encoding function to encode the datetime values
+        encoded_values, _, _ = encode_cf_datetime(
+            time_values,
+            units=time_encoding["units"],
+            calendar=time_encoding["calendar"],
+        )
+
+        # Replace the time coordinate with the encoded values
+        da[time_label] = xr.DataArray(
+            encoded_values, dims=[time_label], attrs=da[time_label].attrs.copy()
+        )
+
+    # Set time units and calendar as attributes (for metadata)
+    # Only set if they are actual strings (not Mock objects)
+    # But avoid setting calendar attribute if it conflicts with encoding
+    if "units" in time_encoding and isinstance(time_encoding["units"], str):
+        da[time_label].attrs["units"] = time_encoding["units"]
+    # Only set calendar attribute if we have custom calendar (not default "standard")
+    if (
+        "calendar" in time_encoding
+        and isinstance(time_encoding["calendar"], str)
+        and time_encoding["calendar"] != "standard"
+    ):
+        da[time_label].attrs["calendar"] = time_encoding["calendar"]
+
+    # Ensure the encoding is set on the time variable itself
+    if isinstance(da, xr.DataArray):
+        da = da.to_dataset()
+    da[time_label].encoding.update(time_encoding)
 
     if not has_time_axis(da):
         filepath = create_filepath(da, rule)

--- a/tests/unit/test_savedataset.py
+++ b/tests/unit/test_savedataset.py
@@ -223,3 +223,82 @@ def test_save_dataset_saves_to_multiple_files(tmp_path):
     save_dataset(da, rule)
     files = list(t.iterdir())
     assert len(files) == 4
+
+
+def test_save_dataset_with_custom_time_settings(tmp_path):
+    """Test that custom time units and calendar are correctly applied when saving datasets."""
+    # Create a simple dataset with time dimension
+    dates = xr.date_range(
+        start="2000-01-01", periods=2, freq="D", calendar="noleap", use_cftime=True
+    )
+    da = xr.DataArray(
+        np.arange(2),
+        coords=[dates],
+        dims=["time"],
+        name="test_var",
+    )
+
+    # Create a mock rule with custom time settings (following the pattern of other tests)
+    rule = Mock()
+    rule._pycmor_cfg = PycmorConfigManager.from_pycmor_cfg({})
+    rule.data_request_variable = Mock()
+    rule.data_request_variable.frequency = "day"
+    rule.data_request_variable.table = Mock()
+    rule.data_request_variable.table.table_id = "Amon"
+    rule.data_request_variable.table_header = Mock()
+    rule.data_request_variable.table_header.approx_interval = 1
+
+    # Set other required attributes
+    rule.cmor_variable = "tas"
+    rule.variant_label = "r1i1p1f1"
+    rule.source_id = "test_model"
+    rule.experiment_id = "test_exp"
+    rule.file_timespan = "1D"
+    rule.output_directory = str(tmp_path)
+    rule.inputs = []  # Mock the inputs attribute to avoid iteration errors
+    rule.adjust_timestamp = None  # Add this to avoid the Mock object error
+
+    # Set custom time units and calendar
+    custom_units = "days since 1850-01-01"
+    custom_calendar = "proleptic_gregorian"
+    rule.time_units = custom_units
+    rule.time_calendar = custom_calendar
+
+    # Save the dataset
+    save_dataset(da, rule)
+
+    # Check that the file was created
+    saved_files = list(tmp_path.glob("*.nc"))
+    assert len(saved_files) > 0, "No NetCDF file was created"
+
+    # Check the actual NetCDF file attributes using netCDF4 directly
+    import netCDF4 as nc
+
+    with nc.Dataset(saved_files[0], "r") as ncfile:
+        assert "time" in ncfile.variables, "Time variable not found in saved dataset"
+        time_var_nc = ncfile.variables["time"]
+
+        # Check if our custom units and calendar are in the NetCDF file
+        nc_units = getattr(time_var_nc, "units", None)
+        nc_calendar = getattr(time_var_nc, "calendar", None)
+
+        # Test against the NetCDF file directly
+        assert (
+            nc_units == custom_units
+        ), f"NetCDF units do not match. Expected {custom_units}, got {nc_units}"
+        assert (
+            nc_calendar == custom_calendar
+        ), f"NetCDF calendar does not match. Expected {custom_calendar}, got {nc_calendar}"
+
+    # Also verify with xarray that the encoding is preserved
+    with xr.open_dataset(saved_files[0]) as ds:
+        assert "time" in ds.variables, "Time variable not found in saved dataset"
+        time_var = ds.variables["time"]
+
+        # Verify the encoding contains our custom units and calendar
+        assert (
+            time_var.encoding["units"] == custom_units
+        ), f"XArray encoding units do not match. Expected {custom_units}, got {time_var.encoding['units']}"
+        assert (
+            time_var.encoding["calendar"] == custom_calendar
+        ), f"XArray encoding calendar does not match. Expected {custom_calendar}, got {time_var.encoding['calendar']}"


### PR DESCRIPTION
## 🎯 **Overview**

This PR adds support for custom time units and calendar settings in pycmor's NetCDF output generation, addressing issue #215. Users can now specify custom time reference dates and calendar types for historical experiments and specialized use cases.

## 🚀 **New Features**

### Custom Time Configuration
- **`time_units`**: CF-compliant time units (e.g., `"days since 1850-01-01"`)
- **`time_calendar`**: Calendar type (e.g., `"proleptic_gregorian"`, `"noleap"`, etc.)

### Example Usage
```yaml
rules:
  - name: historical_experiment
    cmor_variable: "tas"
    # ... other fields ...
    time_units: "days since 1850-01-01"
    time_calendar: "proleptic_gregorian"